### PR TITLE
테스트 결과 슬랙 노티에 테스트 디바이스 정보 추가

### DIFF
--- a/android_automation/dajjeong_run_testcase.py
+++ b/android_automation/dajjeong_run_testcase.py
@@ -32,6 +32,9 @@ class AndroidTestAutomation(unittest.TestCase):
         self.total_time = ''
         self.slack_result = ''
 
+        self.device_platform = self.and_cap.capabilities['platformName']
+        self.device_name = self.and_cap.capabilities['appium:deviceName']
+
     def tearDown(self):
         try:
             self.wd.close_app()
@@ -48,8 +51,6 @@ class AndroidTestAutomation(unittest.TestCase):
     def test_sample_def_name(self):
         # 테스트 자동화 실행 return값을 self.result_data에 넣으면 해당 값들을 가지고 slack noti를 보내게 됩니다
         self.def_name = sys._getframe().f_code.co_name
-        self.device_platform = self.and_cap.capabilities['platformName']
-        self.device_name = self.and_cap.capabilities['appium:deviceName']
 
         self.result_data = AutomationTesting.default_test(self, self.wd)
         self.response = slack_result_notifications.slack_notification(self)

--- a/android_automation/dajjeong_run_testcase.py
+++ b/android_automation/dajjeong_run_testcase.py
@@ -1,0 +1,69 @@
+import time
+import unittest
+import sys
+import requests
+
+from appium.webdriver.appium_service import AppiumService
+from android_setup import dajjeong_setup
+from android_automation.test_cases.sample_test import AutomationTesting
+from com_utils import slack_result_notifications
+
+
+class AndroidTestAutomation(unittest.TestCase):
+
+    def setUp(self):
+        # user_info = requests.get(f"http://192.168.103.13:50/qa/personal/{os.environ.get('user')}")
+        user_info = requests.get(f"http://192.168.103.13:50/qa/personal/mpark")
+        self.pconf = user_info.json()
+        public_info = requests.get(f"http://192.168.103.13:50/qa/personal/info")
+        self.conf = public_info.json()
+
+        # Appium Service
+        self.appium = AppiumService()
+        self.appium.start(args=['-p', '4923', '--base-path', '/wd/hub', '--default-capabilities',
+                                '{"appium:chromedriverExecutable": "/usr/local/bin/chromedriver"}'])
+
+        # webdriver
+        self.wd, self.and_cap = dajjeong_setup()
+        self.wd.implicitly_wait(5)
+
+        # report data
+        self.count = 0
+        self.total_time = ''
+        self.slack_result = ''
+
+    def tearDown(self):
+        try:
+            self.wd.close_app()
+            print('앱 종료 실행')
+            self.wd.quit()
+            print('wd quit 실행')
+            time.sleep(2)
+            self.appium.stop()
+            print('appium service stop 성공')
+        except Exception:
+            self.appium.stop()
+            print('exception')
+
+    def test_sample_def_name(self):
+        # 테스트 자동화 실행 return값을 self.result_data에 넣으면 해당 값들을 가지고 slack noti를 보내게 됩니다
+        self.def_name = sys._getframe().f_code.co_name
+        self.device_platform = self.and_cap.capabilities['platformName']
+        self.device_name = self.and_cap.capabilities['appium:deviceName']
+
+        self.result_data = AutomationTesting.default_test(self, self.wd)
+        self.response = slack_result_notifications.slack_notification(self)
+        self.count = slack_result_notifications.slack_thread_notification(self)
+        self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
+        self.result_data = AutomationTesting.default_fail_test(self, self.wd)
+        self.count = slack_result_notifications.slack_thread_notification(self)
+        self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
+        self.result_data = AutomationTesting.default_test(self, self.wd)
+        self.count = slack_result_notifications.slack_thread_notification(self)
+        self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -36,6 +36,10 @@ class IOSTestAutomation(unittest.TestCase):
         self.total_time = ''
         self.slack_result = ''
 
+        # 테스트 수행 디바이스 정보(플랫폼, 디바이스명)
+        self.device_platform = self.iOS_cap.capabilities['platformName']
+        self.device_name = self.iOS_cap.capabilities['appium:deviceName']
+
     def tearDown(self):
         try:
             self.wd.terminate_app('kr.co.29cm.App29CM')
@@ -53,9 +57,6 @@ class IOSTestAutomation(unittest.TestCase):
     def test_iOS_bvt(self):
 
         self.def_name = sys._getframe().f_code.co_name
-        # 테스트 수행 디바이스 정보(플랫폼, 디바이스명)
-        self.device_platform = self.iOS_cap.capabilities['platformName']
-        self.device_name = self.iOS_cap.capabilities['appium:deviceName']
 
         # 비로그인 유저 사용 불가
         self.result_data = NotLoginUserTest.test_not_login_user_impossible(self, self.wd)
@@ -75,8 +76,6 @@ class IOSTestAutomation(unittest.TestCase):
 
     def test_iOS_full(self):
         self.def_name = sys._getframe().f_code.co_name
-        self.device_platform = self.iOS_cap.capabilities['platformName']
-        self.device_name = self.iOS_cap.capabilities['appium:deviceName']
 
         # 비로그인 유저 사용 불가
         self.result_data = NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -1,14 +1,13 @@
-
+import re
+import unittest
+import requests
 import os
 import sys
+
 iOS_path = os.path.join(os.path.dirname(__file__), '..')
 sys.path.append(iOS_path)
-import time
-import unittest
 
-import requests
 from appium.webdriver.appium_service import AppiumService
-
 from com_utils import slack_result_notifications
 from ios_setup import dajjeong_setup
 from ios_automation.test_cases.login_test import UserLoginTest
@@ -21,7 +20,8 @@ class IOSTestAutomation(unittest.TestCase):
     def setUp(self):
         # Appium Service
         self.appium = AppiumService()
-        self.appium.start(args=['-p', '4924', '--base-path', '/wd/hub', '--default-capabilities', '{"appium:chromedriverExecutable": "/usr/local/bin"}'])
+        self.appium.start(args=['-p', '4924', '--base-path', '/wd/hub', '--default-capabilities',
+                                '{"appium:chromedriverExecutable": "/usr/local/bin"}'])
 
         # webdriver
         self.wd, self.iOS_cap = dajjeong_setup()
@@ -53,6 +53,9 @@ class IOSTestAutomation(unittest.TestCase):
     def test_iOS_bvt(self):
 
         self.def_name = sys._getframe().f_code.co_name
+        # 테스트 수행 디바이스 정보(플랫폼, 디바이스명)
+        self.device_platform = self.iOS_cap.capabilities['platformName']
+        self.device_name = self.iOS_cap.capabilities['appium:deviceName']
 
         # 비로그인 유저 사용 불가
         self.result_data = NotLoginUserTest.test_not_login_user_impossible(self, self.wd)
@@ -72,13 +75,14 @@ class IOSTestAutomation(unittest.TestCase):
 
     def test_iOS_full(self):
         self.def_name = sys._getframe().f_code.co_name
+        self.device_platform = self.iOS_cap.capabilities['platformName']
+        self.device_name = self.iOS_cap.capabilities['appium:deviceName']
 
         # 비로그인 유저 사용 불가
         self.result_data = NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)
         self.response = slack_result_notifications.slack_notification(self)
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
-
 
 
 if __name__ == '__main__':

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -13,7 +13,7 @@ class NotLoginUserTest:
 
     def check_login_page(self, wd):
 
-        sleep(2)
+        sleep(1)
 
         try:
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, '로그인하기')
@@ -28,7 +28,6 @@ class NotLoginUserTest:
         try:
             sleep(1)
 
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarCartWhite').click()
 
             NotLoginUserTest.check_login_page(self, wd)


### PR DESCRIPTION
1. run_testcase 각 함수에 테스트 디바이스 정보 불러오는 코드 추가
self.device_platform = self.and_cap.capabilities['platformName']
self.device_name = self.and_cap.capabilities['appium:deviceName']
플랫폼에 따라 and_caps / iOS_caps로 작성

2. slack_result_notifications에 해당 정보 전달하는 코드 추가
