### PR TITLE
Cmqat 125/dajjeong

### DIFF
--- a/android_automation/dajjeong_run_testcase.py
+++ b/android_automation/dajjeong_run_testcase.py
@@ -13,7 +13,7 @@ class AndroidTestAutomation(unittest.TestCase):
 
     def setUp(self):
         # user_info = requests.get(f"http://192.168.103.13:50/qa/personal/{os.environ.get('user')}")
-        user_info = requests.get(f"http://192.168.103.13:50/qa/personal/mpark")
+        user_info = requests.get(f"http://192.168.103.13:50/qa/personal/dajjeong")
         self.pconf = user_info.json()
         public_info = requests.get(f"http://192.168.103.13:50/qa/personal/info")
         self.conf = public_info.json()
@@ -49,7 +49,6 @@ class AndroidTestAutomation(unittest.TestCase):
             print('exception')
 
     def test_sample_def_name(self):
-        # 테스트 자동화 실행 return값을 self.result_data에 넣으면 해당 값들을 가지고 slack noti를 보내게 됩니다
         self.def_name = sys._getframe().f_code.co_name
 
         self.result_data = AutomationTesting.default_test(self, self.wd)

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -81,6 +81,9 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
+    def test_test(self):
+        NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -81,9 +81,6 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
-    def test_test(self):
-        NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -27,7 +27,7 @@ class IOSTestAutomation(unittest.TestCase):
         self.wd, self.iOS_cap = dajjeong_setup()
         self.wd.implicitly_wait(3)
 
-        user_info = requests.get(f"http://192.168.103.13:50/qa/personal/mpark")
+        user_info = requests.get(f"http://192.168.103.13:50/qa/personal/dajjeong")
         self.pconf = user_info.json()
         public_info = requests.get(f"http://192.168.103.13:50/qa/personal/info")
         self.conf = public_info.json()
@@ -49,7 +49,6 @@ class IOSTestAutomation(unittest.TestCase):
             self.appium.stop()
             print("appium 종료 완료")
             # subprocess.run(['pkill', '-9', '-f', 'WebDriverAgentRunner'])
-
             print("테스트 종료")
         except InvalidSessionIdException:
             self.appium.stop()
@@ -82,6 +81,9 @@ class IOSTestAutomation(unittest.TestCase):
         self.response = slack_result_notifications.slack_notification(self)
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
+    def test_test(self):
+        NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)
 
 
 if __name__ == '__main__':

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -2,17 +2,17 @@ import re
 import unittest
 import requests
 import os
-import sys
-
-iOS_path = os.path.join(os.path.dirname(__file__), '..')
-sys.path.append(iOS_path)
 
 from appium.webdriver.appium_service import AppiumService
 from com_utils import slack_result_notifications
 from ios_setup import dajjeong_setup
 from ios_automation.test_cases.login_test import UserLoginTest
 from ios_automation.test_cases.not_login_user_test import NotLoginUserTest
-from selenium.common.exceptions import NoSuchElementException, InvalidSessionIdException
+from selenium.common.exceptions import InvalidSessionIdException
+
+import sys
+iOS_path = os.path.join(os.path.dirname(__file__), '..')
+sys.path.append(iOS_path)
 
 
 class IOSTestAutomation(unittest.TestCase):
@@ -36,7 +36,6 @@ class IOSTestAutomation(unittest.TestCase):
         self.total_time = ''
         self.slack_result = ''
 
-        # 테스트 수행 디바이스 정보(플랫폼, 디바이스명)
         self.device_platform = self.iOS_cap.capabilities['platformName']
         self.device_name = self.iOS_cap.capabilities['appium:deviceName']
 
@@ -81,9 +80,6 @@ class IOSTestAutomation(unittest.TestCase):
         self.response = slack_result_notifications.slack_notification(self)
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
-
-    def test_test(self):
-        NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)
 
 
 if __name__ == '__main__':

--- a/ios_automation/test_cases/login_test.py
+++ b/ios_automation/test_cases/login_test.py
@@ -96,25 +96,18 @@ class UserLoginTest:
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="LOGOUT"]').click()
 
         except Exception:
-            # 오류 발생 시 테스트 결과를 실패로 한다
             test_result = 'FAIL'
-            # 스크린샷
             wd.get_screenshot_as_file(sys._getframe().f_code.co_name + '_error.png')
-            # 스크린샷 경로 추출
             img_src = os.path.abspath(sys._getframe().f_code.co_name + '_error.png')
-            # 에러 메시지 추출
             error_text = traceback.format_exc().split('\n')
             try:
-                # 에러메시지 분류 시 예외처리
                 error_texts.append(values_control.find_next_double_value(error_text, 'Traceback'))
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
 
         finally:
-            # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
             run_time = f"{time() - start_time:.2f}"
-            # 값 재사용 용이성을 위해 dict로 반환한다
             result_data = {
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
@@ -128,25 +121,18 @@ class UserLoginTest:
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
 
         except Exception:
-            # 오류 발생 시 테스트 결과를 실패로 한다
             test_result = 'FAIL'
-            # 스크린샷
             wd.get_screenshot_as_file(sys._getframe().f_code.co_name + '_error.png')
-            # 스크린샷 경로 추출
             img_src = os.path.abspath(sys._getframe().f_code.co_name + '_error.png')
-            # 에러 메시지 추출
             error_text = traceback.format_exc().split('\n')
             try:
-                # 에러메시지 분류 시 예외처리
                 error_texts.append(values_control.find_next_double_value(error_text, 'Traceback'))
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
 
         finally:
-            # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
             run_time = f"{time() - start_time:.2f}"
-            # 값 재사용 용이성을 위해 dict로 반환한다
             result_data = {
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -12,27 +12,32 @@ from com_utils import values_control
 class NotLoginUserTest:
 
     def check_login_page(self, wd):
+        test_name = sys._getframe().f_code.co_name
 
-        sleep(1)
+        sleep(2)
 
         try:
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, '로그인하기')
-            print('Pass')
+            result = f'{test_name}: Pass'
         except NoSuchElementException:
-            print('Fail')
+            result = f'{test_name}: Fail'
+
+        wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+
+        return result
 
     def test_not_login_user_impossible(self, wd, test_result='PASS', error_texts=[], img_src=''):
         test_name = sys._getframe().f_code.co_name
         start_time = time()
 
         try:
-            sleep(1)
-
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarCartWhite').click()
-
-            NotLoginUserTest.check_login_page(self, wd)
-
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '상의').click()
+            wd.find_element(AppiumBy.XPATH, '(//XCUIElementTypeButton[@name="icHeartLine"])[2]').click()
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="확인"]').click()
+            sleep(2)
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarBackBlack').click()
 
         except Exception:
             # 오류 발생 시 테스트 결과를 실패로 한다
@@ -69,25 +74,18 @@ class NotLoginUserTest:
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
-            # 오류 발생 시 테스트 결과를 실패로 한다
             test_result = 'FAIL'
-            # 스크린샷
             wd.get_screenshot_as_file(sys._getframe().f_code.co_name + '_error.png')
-            # 스크린샷 경로 추출
             img_src = os.path.abspath(sys._getframe().f_code.co_name + '_error.png')
-            # 에러 메시지 추출
             error_text = traceback.format_exc().split('\n')
             try:
-                # 에러메시지 분류 시 예외처리
                 error_texts.append(values_control.find_next_double_value(error_text, 'Traceback'))
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
 
         finally:
-            # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
             run_time = f"{time() - start_time:.2f}"
-            # 값 재사용 용이성을 위해 dict로 반환한다
             result_data = {
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
@@ -100,43 +98,76 @@ class NotLoginUserTest:
         try:
             sleep(1)
 
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarCartWhite').click()
-            NotLoginUserTest.check_login_page(self, wd)
+            # 주요 시나리오
+            NotLoginUserTest.test_not_login_user_impossible(self, wd)
 
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+            # 속도를 위해 MY 탭으로 시작 위치 변경
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
 
+            # 상단 네비게이션 알림 버튼 선택
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarNotiWhite').click()
             NotLoginUserTest.check_login_page(self, wd)
 
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+            # 상단 네비게이션 장바구니 버튼 선택
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarCartWhite').click()
+            print(NotLoginUserTest.check_login_page(self, wd))
 
+            # LIKE 탭 선택
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="LIKE"]').click()
             NotLoginUserTest.check_login_page(self, wd)
 
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+            # PDP > 구매하기 선택
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '상의').click()
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeCollectionView/XCUIElementTypeCell[1]').click()
+            sleep(2)
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '구매하기').click()
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '바로 구매하기').click()
+
+            try:
+                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="쿠폰"]')
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
+            except NoSuchElementException:
+                print("쿠폰 없음")
+            print(NotLoginUserTest.check_login_page(self, wd))
+
 
         except Exception:
-            # 오류 발생 시 테스트 결과를 실패로 한다
             test_result = 'FAIL'
-            # 스크린샷
             wd.get_screenshot_as_file(sys._getframe().f_code.co_name + '_error.png')
-            # 스크린샷 경로 추출
             img_src = os.path.abspath(sys._getframe().f_code.co_name + '_error.png')
-            # 에러 메시지 추출
             error_text = traceback.format_exc().split('\n')
             try:
-                # 에러메시지 분류 시 예외처리
                 error_texts.append(values_control.find_next_double_value(error_text, 'Traceback'))
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
 
         finally:
-            # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
             run_time = f"{time() - start_time:.2f}"
-            # 값 재사용 용이성을 위해 dict로 반환한다
             result_data = {
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
             return result_data
+
+    def test(self, wd):
+        wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
+        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '상의').click()
+        wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeCollectionView/XCUIElementTypeCell[1]').click()
+        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '구매하기').click()
+        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '바로 구매하기').click()
+
+        try:
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="쿠폰"]')
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
+        except NoSuchElementException:
+            print("쿠폰 없음")
+
+        print(NotLoginUserTest.check_login_page(self, wd))
+        wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+
+
+
+
+
+

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -11,6 +11,7 @@ from com_utils import values_control
 
 class NotLoginUserTest:
 
+    # 로그인 페이지 진입 확인 메소드. [로그인하기] 버튼의 노출 여부를 판단한다.
     def check_login_page(self, wd):
         test_name = sys._getframe().f_code.co_name
 
@@ -108,7 +109,7 @@ class NotLoginUserTest:
 
             # 상단 네비게이션 장바구니 버튼 선택
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarCartWhite').click()
-            print(NotLoginUserTest.check_login_page(self, wd))
+            NotLoginUserTest.check_login_page(self, wd)
 
             # LIKE 탭 선택
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="LIKE"]').click()
@@ -124,10 +125,10 @@ class NotLoginUserTest:
 
             try:
                 wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="쿠폰"]')
-                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
             except NoSuchElementException:
                 print("쿠폰 없음")
-            print(NotLoginUserTest.check_login_page(self, wd))
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
+            NotLoginUserTest.check_login_page(self, wd)
 
 
         except Exception:

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -56,9 +56,7 @@ class NotLoginUserTest:
                 pass
 
         finally:
-            # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
             run_time = f"{time() - start_time:.2f}"
-            # 값 재사용 용이성을 위해 dict로 반환한다
             result_data = {
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
@@ -149,24 +147,6 @@ class NotLoginUserTest:
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
             return result_data
-
-    def test(self, wd):
-        wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
-        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '상의').click()
-        wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeCollectionView/XCUIElementTypeCell[1]').click()
-        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '구매하기').click()
-        wd.find_element(AppiumBy.ACCESSIBILITY_ID, '바로 구매하기').click()
-
-        try:
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="쿠폰"]')
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
-        except NoSuchElementException:
-            print("쿠폰 없음")
-
-        print(NotLoginUserTest.check_login_page(self, wd))
-        wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
-
-
 
 
 

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -123,11 +123,13 @@ class NotLoginUserTest:
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, '구매하기').click()
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, '바로 구매하기').click()
 
+            # 바로 구매하기 버튼 선택 시, 쿠폰 선택 바텀 시트 노출 여부 확인
+            # 바텀 시트 노출 시, 바텀 시트의 닫기 버튼 선택하여 로그인 페이지 진입
             try:
                 wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="쿠폰"]')
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
             except NoSuchElementException:
                 print("쿠폰 없음")
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '닫기').click()
             NotLoginUserTest.check_login_page(self, wd)
 
 


### PR DESCRIPTION
왜 반복적인 커밋이 계속 들어갔을까요...
변경점은 아래와 같습니다.
1. 주석 제거
2. 비로그인 유저가 사용 불가한 기능의 주요 시나리오를 변경하였습니다.
as-is : Home의 장바구니 아이콘 선택
to-be : plp 에서 좋아요 버튼 선택
3. 비로그인 유저 확장 시나리오 추가 작성
4. 로그인 페이지에서 뒤로가기 버튼 선택 코드를 check_login_page() 메소드 안으로 이동