### PR TITLE
Cmqat 126/dajjeong

### DIFF
--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -88,9 +88,6 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
-    def test(self):
-        NotLoginUserTest.test_not_login_user_possible(self, self.wd)
-        UserLoginTest.test_login_error(self, self.wd)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -75,7 +75,7 @@ class IOSTestAutomation(unittest.TestCase):
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
     def test_iOS_full(self):
-        self.def_name = sys._getframe().f_code.co_name
+        self.def_name = self.dconf[sys._getframe().f_code.co_name]
 
         # 비로그인 유저 사용 불가
         self.result_data = NotLoginUserTest.full_test_not_login_user_impossible(self, self.wd)

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -69,13 +69,18 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
-        # 로그인 테스트
-        self.result_data = UserLoginTest.test_login(self, self.wd)
+        # 이메일 로그인 실패
+        self.result_data = UserLoginTest.test_email_login_error(self, self.wd)
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
-        # 로그인 실패 테스트
-        self.result_data = UserLoginTest.test_login_error(self, self.wd)
+        # 이메일 로그인 성공
+        self.result_data = UserLoginTest.test_email_login_success(self, self.wd)
+        self.count = slack_result_notifications.slack_thread_notification(self)
+        self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
+        # 로그아웃
+        self.result_data = UserLoginTest.test_logout(self, self.wd)
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 

--- a/ios_automation/run_testcase.py
+++ b/ios_automation/run_testcase.py
@@ -64,6 +64,11 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
+        # 비로그인 유저 사용 가능
+        self.result_data = NotLoginUserTest.test_not_login_user_possible(self, self.wd)
+        self.count = slack_result_notifications.slack_thread_notification(self)
+        self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
+
         # 로그인 테스트
         self.result_data = UserLoginTest.test_login(self, self.wd)
         self.count = slack_result_notifications.slack_thread_notification(self)
@@ -83,6 +88,9 @@ class IOSTestAutomation(unittest.TestCase):
         self.count = slack_result_notifications.slack_thread_notification(self)
         self.total_time, self.slack_result = slack_result_notifications.slack_update_notification(self)
 
+    def test(self):
+        NotLoginUserTest.test_not_login_user_possible(self, self.wd)
+        UserLoginTest.test_login_error(self, self.wd)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ios_automation/test_cases/login_test.py
+++ b/ios_automation/test_cases/login_test.py
@@ -84,7 +84,7 @@ class UserLoginTest:
 
             # 프로필 이름 확인
             try:
-                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '정다정')
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, self.pconf['nickname'])
                 print("로그인 성공")
             except:
                 print("로그인 실패")
@@ -119,7 +119,7 @@ class UserLoginTest:
             # My 탭 진입
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
             try:
-                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '정다정')
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, self.pconf['nickname'])
                 print("로그인 유저")
             except:
                 print("비로그인 유저")

--- a/ios_automation/test_cases/login_test.py
+++ b/ios_automation/test_cases/login_test.py
@@ -1,13 +1,9 @@
 import os.path
 import sys
 import traceback
-import json
 
 from time import sleep, time
 from appium.webdriver.common.appiumby import AppiumBy
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as ec
-from selenium.webdriver.support.wait import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
 from com_utils import values_control
 
@@ -20,33 +16,31 @@ class UserLoginTest:
         wd.find_element(AppiumBy.IOS_PREDICATE, 'value=="비밀번호"').send_keys(password)
         wd.find_element(AppiumBy.ACCESSIBILITY_ID, '로그인하기').click()
 
-    def test_login_error(self, wd, test_result='PASS', error_texts=[], img_src=''):
-        test_name = sys._getframe().f_code.co_name
+    def test_email_login_error(self, wd, test_result='PASS', error_texts=[], img_src=''):
+        test_name = self.dconf[sys._getframe().f_code.co_name]
         start_time = time()
 
         try:
-            try:
-                wd.find_element(AppiumBy.ACCESSIBILITY_ID, "닫기").click()
-            except NoSuchElementException:
-                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
-
+            # 로그인 페이지 진입
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="로그인·회원가입"]').click()
+            sleep(3)
 
+            # 올바른 이메일, 잘못된 비밀번호 입력하여 에러 문구 확인
+            UserLoginTest.input_id_password(self, wd, self.pconf['id_29cm'], self.pconf['error_password_29cm'])
             sleep(1)
-
-            UserLoginTest.input_id_password(self, wd, self.pconf['error_id_29cm'], self.pconf['password_29cm'])
-
-            sleep(1)
-
             error = wd.find_element(AppiumBy.XPATH,
                                     '//XCUIElementTypeOther[@name="로그인 - 감도 깊은 취향 셀렉트샵 29CM"]/XCUIElementTypeOther[1]/XCUIElementTypeStaticText').text
             error_login_text = "5회 로그인 실패 시, 로그인이 10분 동안 제한됩니다."
-            print(error)
 
             if error_login_text in error:
-                print(test_name + ": Pass")
+                print("이메일 로그인 실패 확인")
             else:
-                print(test_name + ": Fail")
+                print("이메일 로그인 실패 확인 불가")
+
+            # Home으로 복귀
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
             # 오류 발생 시 테스트 결과를 실패로 한다
@@ -63,6 +57,7 @@ class UserLoginTest:
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
+            wd.get('app29cm://home')
 
         finally:
             # 함수 완료 시 시간체크하여 시작시 체크한 시간과의 차이를 테스트 소요시간으로 반환
@@ -73,22 +68,29 @@ class UserLoginTest:
                 'test_name': test_name, 'run_time': run_time}
             return result_data
 
-    def test_login(self, wd, test_result='PASS', error_texts=[], img_src=''):
-        test_name = sys._getframe().f_code.co_name
+    def test_email_login_success(self, wd, test_result='PASS', error_texts=[], img_src=''):
+        test_name = self.dconf[sys._getframe().f_code.co_name]
         start_time = time()
 
         try:
-            sleep(1)
+            # 로그인 페이지 진입
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="로그인·회원가입"]').click()
+            sleep(3)
 
-            sleep(1)
-
+            # 올바른 아이디, 올바른 비밀번호 입력
             UserLoginTest.input_id_password(self, wd, self.pconf['id_29cm'], self.pconf['password_29cm'])
-
             sleep(1)
 
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="LOGOUT"]').click()
+            # 프로필 이름 확인
+            try:
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '정다정')
+                print("로그인 성공")
+            except:
+                print("로그인 실패")
+
+            # Home 으로 복귀
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
             test_result = 'FAIL'
@@ -100,6 +102,7 @@ class UserLoginTest:
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
+            wd.get('app29cm://home')
 
         finally:
             run_time = f"{time() - start_time:.2f}"
@@ -108,12 +111,35 @@ class UserLoginTest:
                 'test_name': test_name, 'run_time': run_time}
             return result_data
 
-    def full_test_login_error(self, wd, test_result='PASS', error_texts=[], img_src=''):
-        test_name = sys._getframe().f_code.co_name
+    def test_logout(self, wd, test_result='PASS', error_texts=[], img_src=''):
+        test_name = self.dconf[sys._getframe().f_code.co_name]
         start_time = time()
 
         try:
+            # My 탭 진입
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
+            try:
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '정다정')
+                print("로그인 유저")
+            except:
+                print("비로그인 유저")
+
+            # 로그아웃 버튼 선택
+            wd.execute_script('mobile:swipe', {'direction': 'up'})
+            wd.execute_script('mobile:swipe', {'direction': 'up'})
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="LOGOUT"]').click()
+
+            # 로그아웃 완료 후 문구 확인
+            wd.execute_script('mobile:swipe', {'direction': 'down'})
+            wd.execute_script('mobile:swipe', {'direction': 'down'})
+            try:
+                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="로그인·회원가입"]')
+                print('로그아웃 완료')
+            except NoSuchElementException:
+                print('로그아웃 실패')
+
+            # Home 으로 복귀
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
             test_result = 'FAIL'
@@ -125,6 +151,7 @@ class UserLoginTest:
                 error_texts.append(values_control.find_next_value(error_text, 'Stacktrace'))
             except Exception:
                 pass
+            wd.get('app29cm://home')
 
         finally:
             run_time = f"{time() - start_time:.2f}"

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -5,7 +5,6 @@ from time import time, sleep
 
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.common.exceptions import NoSuchElementException
-
 from com_utils import values_control
 
 
@@ -40,6 +39,7 @@ class NotLoginUserTest:
             sleep(2)
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common back icon black').click()
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarBackBlack').click()
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
             # 오류 발생 시 테스트 결과를 실패로 한다
@@ -92,7 +92,7 @@ class NotLoginUserTest:
             return result_data
 
     def full_test_not_login_user_impossible(self, wd, test_result='PASS', error_texts=[], img_src=''):
-        test_name = sys._getframe().f_code.co_name
+        test_name = self.dconf[sys._getframe().f_code.co_name]
         start_time = time()
 
         try:
@@ -100,9 +100,6 @@ class NotLoginUserTest:
 
             # 주요 시나리오
             NotLoginUserTest.test_not_login_user_impossible(self, wd)
-
-            # 속도를 위해 MY 탭으로 시작 위치 변경
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
 
             # 상단 네비게이션 알림 버튼 선택
             wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarNotiWhite').click()
@@ -132,6 +129,7 @@ class NotLoginUserTest:
             except NoSuchElementException:
                 print("쿠폰 없음")
             NotLoginUserTest.check_login_page(self, wd)
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
 
         except Exception:

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -48,9 +48,9 @@ class NotLoginUserTest:
 
             # 로그인 페이지 진입 및 확인
             NotLoginUserTest.check_login_page(self, wd)
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarBackBlack').click()
 
             # Home 탭으로 복귀
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarBackBlack').click()
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
 
         except Exception:
@@ -79,42 +79,53 @@ class NotLoginUserTest:
         start_time = time()
 
         try:
-            # Category 탭으로 이동하여 추천 상품 PLP 진입
-            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'FOR YOU').click()
-            try:
-                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="당신을 위한 추천상품"]')
-                logger.info('추천 카테고리 PLP 진입 성공')
-            except NoSuchElementException:
-                logger.warning('추천 카테고리 PLP 진입 실패')
+            # Home > 베스트 탭 선택하여 베스트 PLP 진입
+            wd.execute_script('mobile:swipe', {'direction': 'up'})
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '베스트').click()
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="전체보기"]').click()
 
-            # 추천 상품 PLP에서 첫번째 상품 선택
+            # 베스트 PLP에서 첫번째 상품명 저장하고 PDP 진입
             plp_product = wd.find_element(AppiumBy.XPATH,
-                                          '//XCUIElementTypeCollectionView/XCUIElementTypeCell[1]/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeStaticText[@index="1"]')
+                                          '//XCUIElementTypeCollectionView/XCUIElementTypeCell[2]/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeStaticText[@index="1"]')
             plp_name = plp_product.text
             plp_product.click()
 
             # 선택한 상품의 PDP에서 상품 이름 비교
-            pdp_name = wd.find_element(AppiumBy.XPATH,
+            pdp_name_text = wd.find_element(AppiumBy.XPATH,
                                        '//XCUIElementTypeWebView/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther').text
-            if plp_name in pdp_name:
+            pdp_name = pdp_name_text.strip(' - 감도 깊은 취향 셀렉트샵 29CM')
+            if pdp_name in plp_name:
                 logger.info('PDP 페이지 진입 성공')
-                pass
             else:
                 logger.warning(f'PDP 페이지 진입 실패 : {plp_name} / {pdp_name}')
 
+            # PDP 상단 네비게이션의 Home 아이콘 선택하여 Home 복귀
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common home icon black').click()
+
+            # Home > 추천 탭 상단의 타이틀 비교 (비로그인 유저 : 당신)
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, '추천').click()
+            try:
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, '당신을 위한 추천 상품')
+                logger.info('비로그인 유저 추천 탭 진입 확인')
+            except NoSuchElementException:
+                logger.warning('비로그인 유저 추천 탭 진입 실패')
+
             # 상단 검색 버튼 선택하여 인기 브랜드 10위 선택
-            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common search icon black').click()
+            # 상단 검색 버튼명(색상)이 스크롤 정도에 따라 다르게 노출되어 try-except문으로 확인(하얀색이 아니면 검정색으로)
+            try:
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarSearchWhite').click()
+            except:
+                wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'icNavigationbarSearchBlack').click()
             search_brand = wd.find_element(AppiumBy.XPATH,
                                            '//XCUIElementTypeCollectionView/XCUIElementTypeCell[@index="9"]/XCUIElementTypeOther/XCUIElementTypeStaticText[@index="1"]')
             search_brand_name = search_brand.text
             search_brand.click()
 
+            # 검색 결과 화면 진입하여 선택한 브랜드명과 입력란의 문구 비교 확인
             sleep(3)
             search_input_field = wd.find_element(AppiumBy.CLASS_NAME, 'XCUIElementTypeTextField').text
             if search_input_field == search_brand_name:
                 logger.info('검색 결과 화면 진입 성공')
-                pass
             else:
                 logger.warning(f'검색 결과 화면 진입 실패 : {search_brand_name} / {search_input_field}')
 

--- a/ios_automation/test_cases/not_login_user_test.py
+++ b/ios_automation/test_cases/not_login_user_test.py
@@ -65,13 +65,58 @@ class NotLoginUserTest:
             return result_data
 
     def test_not_login_user_possible(self, wd, test_result='PASS', error_texts=[], img_src=''):
-        test_name = sys._getframe().f_code.co_name
+        test_name = self.dconf[sys._getframe().f_code.co_name]
         start_time = time()
 
         try:
-            sleep(1)
+            # Category 탭으로 이동하여 추천 상품 PLP 진입
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="CATEGORY"]').click()
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'FOR YOU').click()
+            try:
+                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="당신을 위한 추천상품"]')
+                print('추천 카테고리 PLP 진입 성공')
+            except NoSuchElementException:
+                print('추천 카테고리 PLP 진입 실패')
 
+            # 추천 상품 PLP에서 첫번째 상품 선택
+            plp_product = wd.find_element(AppiumBy.XPATH,
+                                          '//XCUIElementTypeCollectionView/XCUIElementTypeCell[1]/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeStaticText[@index="1"]')
+            plp_name = plp_product.text
+            plp_product.click()
+
+            # 선택한 상품의 PDP에서 상품 이름 비교
+            pdp_name = wd.find_element(AppiumBy.XPATH,
+                                       '//XCUIElementTypeWebView/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther').text
+            if plp_name in pdp_name:
+                print("PDP 페이지 진입 성공")
+            else:
+                print("PDP 페이지 진입 실패")
+
+            # 상단 검색 버튼 선택하여 인기 브랜드 10위 선택
+            wd.find_element(AppiumBy.ACCESSIBILITY_ID, 'common search icon black').click()
+            search_brand = wd.find_element(AppiumBy.XPATH,
+                                           '//XCUIElementTypeCollectionView/XCUIElementTypeCell[@index="9"]/XCUIElementTypeOther/XCUIElementTypeStaticText[@index="1"]')
+            search_brand_name = search_brand.text
+            search_brand.click()
+
+            search_input_field = wd.find_element(AppiumBy.CLASS_NAME, '//XCUIElementTypeTextField').text
+            if search_input_field == search_brand_name:
+                print("검색 결과 화면 진입 성공")
+            else:
+                print("검색 결과 화면 진입 실패")
+
+            # My 탭 진입하여 로그인,회원가입 문구 노출 확인
+            wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="MY"]').click()
+            try:
+                wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeStaticText[@name="로그인·회원가입"]')
+                print("My 탭 진입 성공")
+            except NoSuchElementException:
+                print("My 탭 진입 실패")
+
+            # Home 탭으로 복귀
             wd.find_element(AppiumBy.XPATH, '//XCUIElementTypeButton[@name="HOME"]').click()
+
+            sleep(3)
 
         except Exception:
             test_result = 'FAIL'
@@ -149,7 +194,3 @@ class NotLoginUserTest:
                 'test_result': test_result, 'error_texts': error_texts, 'img_src': img_src,
                 'test_name': test_name, 'run_time': run_time}
             return result_data
-
-
-
-


### PR DESCRIPTION
1. 비로그인 유저 시나리오 작성 완료 했습니다.
- 테스트 시작 시점을 모두 Home 화면에서 시작하도록 변경
2. 로그인, 로그아웃 시나리오 수정했습니다.
- 시나리오 변경 발생
- 테스트명 한글로 노출되도록 변경
3. 비로그인 유저의 시나리오에서 print()를 logging()으로 변경했습니다.
- 해당 부분은 결정되는 방향으로 수정하겠습니다.
4. 테스트 실패 시, 딥링크로 Home 탭 이동하는 코드 추가했습니다.