### PR TITLE
Cmqat 454/dajjeong

### DIFF
--- a/com_utils/api_control.py
+++ b/com_utils/api_control.py
@@ -453,6 +453,19 @@ def product_detail(product_item_no):
         print('PDP 상세 정보 API 불러오기 실패')
 
 
+def product_item_option_no(product_item_no):
+    option_id = ''
+    option = product_detail(product_item_no)['option_items_list']
+    if not option:
+        option_id = None
+    else:
+        option_list = product_no_soldout_option(product_item_no)
+        for list, value in option_list.items():
+            if list.startswith('id'):
+                option_id = value
+    return option_id
+
+
 def product_no_soldout_option(product_item_no):
     option_layout = product_detail(product_item_no)['option_items_layout']
     option_item_list = product_detail(product_item_no)['option_items_list']
@@ -572,3 +585,45 @@ def my_order_cancel(id, password, order_serial_no):
     else:
         print(response.status_code)
         print('주문 취소 API 불러오기 실패')
+
+
+def cart_product_count(id, password):
+    cookies = com_utils.cookies_control.cookie_29cm(id, password)
+    response = requests.get('https://commerce-api.29cm.co.kr/api/v4/cart-item/item-count', cookies=cookies)
+    if response.status_code == 200:
+        cart_data = response.json()
+        cart_count = cart_data['data']['count']
+        return cart_count
+    else:
+        print('장바구니 상품 개수 조회 API 불러오기 실패')
+
+
+def add_product_to_cart(id, password):
+    item_id = order_product_random_no()
+    option_id = product_item_option_no(item_id)
+
+    headers = {'Content-Type': 'application/json'}
+    cookies = com_utils.cookies_control.cookie_29cm(id, password)
+    data = json.dumps({
+        "cartItemList": [
+            {
+                "itemId": item_id,
+                "optionId": option_id,
+                "orderCount": 1,
+                "requestComment": None,
+                "isOrderCheck": False,
+                "isNaverAccess": False
+            }
+        ]
+    })
+
+    response = requests.post('https://commerce-api.29cm.co.kr/api/v4/cart-item/',
+                             headers=headers, cookies=cookies, data=data)
+    if response.status_code == 200:
+        cart_data = response.json()
+        if cart_data['result'] == 'SUCCESS':
+            print('장바구니에 상품 담기 성공 확인')
+        else:
+            print('장바구니에 상품 담기 실패 확인')
+    else:
+        print('장바구니 상품 담기 API 불러오기 실패')

--- a/com_utils/api_control.py
+++ b/com_utils/api_control.py
@@ -472,6 +472,7 @@ def product_no_soldout_option(product_item_no):
                     if option['limited_qty'] > 3:
                         option_break = True
                         option_list[f'option{i}'] = option_name
+                        option_list['id'] = option["option_no"]
                         break
         if option_break:
             break

--- a/com_utils/deeplink_control.py
+++ b/com_utils/deeplink_control.py
@@ -52,6 +52,11 @@ def move_to_pdp_iOS(wd, product_item_no):
     pdp_close_bottom_sheet(wd)
 
 
+def move_to_cart(self, wd):
+    wd.get(self.conf['deeplink']['cart'])
+    sleep(3)
+
+
 # Home 탭으로 이동 딥링크
 def move_to_home_Android(wd):
     sleep(1)

--- a/ios_automation/page_action/bottom_sheet.py
+++ b/ios_automation/page_action/bottom_sheet.py
@@ -10,6 +10,13 @@ def close_bottom_sheet(wd):
         print('바텀 시트 노출되어 닫기 동작')
     except NoSuchElementException:
         pass
+    try:
+        ial(wd, '//XCUIElementTypeButton[@name="다음"]')
+        ial(wd, '확인하세요')
+        tap_control(wd)
+        print('바텀 시트 노출되어 닫기 동작')
+    except NoSuchElementException:
+        pass
     wd.implicitly_wait(3)
 
 

--- a/ios_automation/page_action/cart_page.py
+++ b/ios_automation/page_action/cart_page.py
@@ -1,6 +1,8 @@
 from time import sleep
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.common import NoSuchElementException
+from com_utils.api_control import cart_product_count, add_product_to_cart
+from com_utils.deeplink_control import move_to_cart
 from com_utils.element_control import ialc, ial, ials
 from ios_automation.page_action import context_change
 
@@ -9,9 +11,8 @@ def click_back_btn(wd):
     ialc(wd, 'common back icon black')
 
 
-def clear_cart_list(wd):
-    wd.get('app29cm://order/cart')
-    sleep(3)
+def clear_cart_list(self, wd):
+    move_to_cart(self, wd)
     try:
         ial(wd, '//XCUIElementTypeLink[@name="CONTINUE SHOPPING"]')
         pass
@@ -104,3 +105,12 @@ def check_add_product(before_count, after_count, before_price, after_price, prod
 def click_check_out_btn(wd):
     ialc(wd, '//button[contains(text(), "CHECK OUT")]')
     sleep(3)
+
+
+def check_need_to_add_product_to_cart(self, wd, id, password):
+    cart_count = cart_product_count(id, password)
+    if cart_count < 2:
+        while cart_count < 2:
+            add_product_to_cart(id, password)
+            cart_count = cart_product_count(id, password)
+        move_to_cart(self, wd)

--- a/ios_automation/page_action/category_page.py
+++ b/ios_automation/page_action/category_page.py
@@ -137,10 +137,10 @@ def save_category_product_name(wd):
 
 
 def check_category_product_name(plp_name, compare_name):
-    if plp_name == compare_name:
+    if compare_name in plp_name:
         print('카테고리 페이지의 상품 확인')
     else:
-        print('카테고리 페이지의 상품 확인 실패')
+        print(f'카테고리 페이지의 상품 확인 실패 : {plp_name} / {compare_name}')
         raise Exception('카테고리 페이지의 상품 확인 실패')
 
 

--- a/ios_automation/page_action/home_page.py
+++ b/ios_automation/page_action/home_page.py
@@ -50,7 +50,8 @@ def save_tab_names(wd):
 # tab : 탭을 보여주는 카테고리 / 전체 : 'home' / 라이프 선택 상태 : 'life'
 # tab_list : 비교할 탭 이름 리스트
 def check_tab_names(self, tab, tab_list):
-    if self.conf['compare_home_tab'][tab] in tab_list:
+    compare_tab = self.conf['compare_home_tab'][tab]
+    if all(tab_name in tab_list for tab_name in compare_tab):
         print(f'홈 상단 {tab} 탭 확인')
     else:
         print(f'홈 상단 {tab} 탭 확인 실패 - {tab_list}')

--- a/ios_automation/page_action/login_page.py
+++ b/ios_automation/page_action/login_page.py
@@ -134,6 +134,6 @@ def click_sns_login_btn(wd, sns_name):
             pass
         ialc(wd, 'AUTHORIZE_BUTTON_TITLE')
     elif sns_name == '네이버':
-        pass
+        sleep(2)
     else:
         ialc(wd, '계속')

--- a/ios_automation/test_cases/cart_test.py
+++ b/ios_automation/test_cases/cart_test.py
@@ -19,7 +19,7 @@ class Cart:
             print(f'[{test_name}] 테스트 시작')
 
             # 테스트 시작 전, 장바구니 비우기
-            cart_page.clear_cart_list(wd)
+            cart_page.clear_cart_list(self, wd)
 
             # 필터를 건 검색 결과 화면에서 랜덤으로 상품번호 저장
             product_item_no = order_product_random_no()
@@ -103,6 +103,9 @@ class Cart:
 
         try:
             print(f'[{test_name}] 테스트 시작')
+
+            # 장바구니 상품 추가 필요 여부 확인
+            cart_page.check_need_to_add_product_to_cart(self, wd, self.pconf['id_29cm'], self.pconf['password_29cm'])
 
             # 웹뷰로 전환
             context_change.switch_context(wd, 'webview')


### PR DESCRIPTION
장바구니 담기 케이스와 수량 변경 케이스의 독립성 확보를 위해 API 요청하여 장바구니 개수 확인 및 상품 담기 할 수 있도록 수정한 PR입니다.
1. 수량 변경 케이스 시작 시점에 API 요청으로 장바구니에 담긴 상품의 개수를 확인
2. 장바구니 상품 수량 2개 미만일 경우, 2개가 될 때까지 장바구니에 랜덤한 상품 담기